### PR TITLE
[VT-7918] Add handling of Exact Alarms

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -235,6 +235,15 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
+     * Returns whether or not the system is allowed to schedule exact alarms
+     *
+     */
+    public void canScheduleExactAlarms(Promise promise) {
+        promise.resolve(mRNPushNotificationHelper.canScheduleExactAlarms());
+    }
+
+    @ReactMethod
+    /**
      * Cancel scheduled notification, and remove notification from the notification centre.
      *
      */

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -226,6 +226,15 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
+     * Opens system settings to the app's page where the user can grant exact alarms permission
+     *
+     */
+    public void openAlarmPermissionSettings() {
+        mRNPushNotificationHelper.openAlarmPermissionSettings();
+    }
+
+    @ReactMethod
+    /**
      * Cancel scheduled notification, and remove notification from the notification centre.
      *
      */

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
@@ -51,7 +51,6 @@ public class RNPushNotificationAttributes {
     private static final String ONGOING = "ongoing";
     private static final String REPLY_BUTTON_TEXT = "reply_button_text";
     private static final String REPLAY_PLACEHOLDER_TEXT = "reply_placeholder_text";
-    private static final String ALLOW_WHILE_IDLE = "allowWhileIdle";
     private static final String IGNORE_IN_FOREGROUND = "ignoreInForeground";
     private static final String USER_INFO = "userInfo";
 
@@ -91,7 +90,6 @@ public class RNPushNotificationAttributes {
     private final boolean ongoing;
     private final String reply_button_text;
     private final String reply_placeholder_text;
-    private final boolean allowWhileIdle;
     private final boolean ignoreInForeground;
     private final String userInfo;
 
@@ -132,7 +130,6 @@ public class RNPushNotificationAttributes {
         ongoing = bundle.getBoolean(ONGOING);
         reply_button_text = bundle.getString(REPLY_BUTTON_TEXT);
         reply_placeholder_text = bundle.getString(REPLAY_PLACEHOLDER_TEXT);
-        allowWhileIdle = bundle.getBoolean(ALLOW_WHILE_IDLE);
         ignoreInForeground = bundle.getBoolean(IGNORE_IN_FOREGROUND);
         userInfo = bundle.getString(USER_INFO);
     }
@@ -175,7 +172,6 @@ public class RNPushNotificationAttributes {
             ongoing = jsonObject.has(ONGOING) ? jsonObject.getBoolean(ONGOING) : false;
             reply_button_text = jsonObject.has(REPLY_BUTTON_TEXT) ? jsonObject.getString(REPLY_BUTTON_TEXT) : null;
             reply_placeholder_text = jsonObject.has(REPLAY_PLACEHOLDER_TEXT) ? jsonObject.getString(REPLAY_PLACEHOLDER_TEXT) : null;
-            allowWhileIdle = jsonObject.has(ALLOW_WHILE_IDLE) ? jsonObject.getBoolean(ALLOW_WHILE_IDLE) : false;
             ignoreInForeground = jsonObject.has(IGNORE_IN_FOREGROUND) ? jsonObject.getBoolean(IGNORE_IN_FOREGROUND) : false;
             userInfo = jsonObject.has(USER_INFO) ? jsonObject.getString(USER_INFO) : null;
         } catch (JSONException e) {
@@ -228,7 +224,6 @@ public class RNPushNotificationAttributes {
         bundle.putBoolean(ONGOING, ongoing);
         bundle.putString(REPLY_BUTTON_TEXT, reply_button_text);
         bundle.putString(REPLAY_PLACEHOLDER_TEXT, reply_placeholder_text);
-        bundle.putBoolean(ALLOW_WHILE_IDLE, allowWhileIdle);
         bundle.putBoolean(IGNORE_IN_FOREGROUND, ignoreInForeground);
         bundle.putString(USER_INFO, userInfo);
         return bundle;
@@ -273,7 +268,6 @@ public class RNPushNotificationAttributes {
             jsonObject.put(ONGOING, ongoing);
             jsonObject.put(REPLY_BUTTON_TEXT, reply_button_text);
             jsonObject.put(REPLAY_PLACEHOLDER_TEXT, reply_placeholder_text);
-            jsonObject.put(ALLOW_WHILE_IDLE, allowWhileIdle);
             jsonObject.put(IGNORE_IN_FOREGROUND, ignoreInForeground);
             jsonObject.put(USER_INFO, userInfo);
         } catch (JSONException e) {
@@ -324,7 +318,6 @@ public class RNPushNotificationAttributes {
                 ", ongoing=" + ongoing +
                 ", reply_button_text=" + reply_button_text +
                 ", reply_placeholder_text=" + reply_placeholder_text +
-                ", allowWhileIdle=" + allowWhileIdle +
                 ", ignoreInForeground=" + ignoreInForeground +
                 ", userInfo=" + userInfo +
                 '}';

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -184,6 +184,20 @@ public class RNPushNotificationHelper {
         }
     }
 
+    public void openAlarmPermissionSettings() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return;
+        }
+        try {
+            Intent intent = new Intent();
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setAction(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM);
+            String packageName = context.getPackageName();
+            intent.setData(Uri.parse("package:" + packageName));
+            context.startActivity(intent);
+        } catch (Exception e) {}
+    }
+
     public boolean canScheduleExactAlarms() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             return getAlarmManager().canScheduleExactAlarms();

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -21,6 +21,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.service.notification.StatusBarNotification;
 import android.text.Spanned;
 import android.util.Log;
@@ -161,7 +162,6 @@ public class RNPushNotificationHelper {
 
     public void sendNotificationScheduledCore(Bundle bundle) {
         long fireDate = (long) bundle.getDouble("fireDate");
-        boolean allowWhileIdle = bundle.getBoolean("allowWhileIdle");
 
         // If the fireDate is in past, this will fire immediately and show the
         // notification to the user
@@ -173,17 +173,23 @@ public class RNPushNotificationHelper {
 
         Log.d(LOG_TAG, String.format("Setting a notification with id %s at time %s",
                 bundle.getString("id"), Long.toString(fireDate)));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            if (allowWhileIdle && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (canScheduleExactAlarms()) {
                 getAlarmManager().setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
             } else {
-                getAlarmManager().setExact(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
+                getAlarmManager().setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
             }
         } else {
             getAlarmManager().set(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
         }
     }
 
+    public boolean canScheduleExactAlarms() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return getAlarmManager().canScheduleExactAlarms();
+        }
+        return true;
+    }
 
     public void sendToNotificationCentre(final Bundle bundle) {
       RNPushNotificationPicturesAggregator aggregator = new RNPushNotificationPicturesAggregator(new RNPushNotificationPicturesAggregator.Callback() {

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -50,6 +50,9 @@ NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
 NotificationsComponent.prototype.openAlarmPermissionSettings = function() {
 	RNPushNotification.openAlarmPermissionSettings();
 };
+NotificationsComponent.prototype.canScheduleExactAlarms = function() {
+	return RNPushNotification.canScheduleExactAlarms();
+};
 
 NotificationsComponent.prototype.presentLocalNotification = function(details) {
 	RNPushNotification.presentLocalNotification(details);

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -47,6 +47,9 @@ NotificationsComponent.prototype.clearLocalNotification = function(details, tag)
 NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
 	RNPushNotification.cancelAllLocalNotifications();
 };
+NotificationsComponent.prototype.openAlarmPermissionSettings = function() {
+	RNPushNotification.openAlarmPermissionSettings();
+};
 
 NotificationsComponent.prototype.presentLocalNotification = function(details) {
 	RNPushNotification.presentLocalNotification(details);

--- a/index.js
+++ b/index.js
@@ -523,6 +523,13 @@ Notifications.openAlarmPermissionSettings = function() {
     return this.callNative('openAlarmPermissionSettings', arguments);
   }
 };
+Notifications.canScheduleExactAlarms = function() {
+  if ( Platform.OS === 'ios' ) {
+    return;
+  } else if (Platform.OS === 'android') {
+    return this.callNative('canScheduleExactAlarms', arguments);
+  }
+};
 
 Notifications.setApplicationIconBadgeNumber = function() {
   return this.callNative('setApplicationIconBadgeNumber', arguments);

--- a/index.js
+++ b/index.js
@@ -516,6 +516,13 @@ Notifications.cancelAllLocalNotifications = function() {
     return this.callNative('cancelAllLocalNotifications', arguments);
   }
 };
+Notifications.openAlarmPermissionSettings = function() {
+  if ( Platform.OS === 'ios' ) {
+    return;
+  } else if (Platform.OS === 'android') {
+    return this.callNative('openAlarmPermissionSettings', arguments);
+  }
+};
 
 Notifications.setApplicationIconBadgeNumber = function() {
   return this.callNative('setApplicationIconBadgeNumber', arguments);


### PR DESCRIPTION
## Story
Closes [VT-7918]

## Changes
- Added a check for permission of exact alarms 
- Made inexact alarms the default, and made exact alarms only be scheduled if one of the following is true:
  - The device is pre Android 13
  - SCHEDULE_EXACT_ALARM permission is granted
- Added a function to grant the permission 

[VT-7918]: https://vantis-health.atlassian.net/browse/VT-7918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ