### PR TITLE
[VT-7918] Set canScheduleExactAlarms to true on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,7 +525,7 @@ Notifications.openAlarmPermissionSettings = function() {
 };
 Notifications.canScheduleExactAlarms = function() {
   if ( Platform.OS === 'ios' ) {
-    return;
+    return true;
   } else if (Platform.OS === 'android') {
     return this.callNative('canScheduleExactAlarms', arguments);
   }


### PR DESCRIPTION
## Story
Partially Closes [VW-7918](https://vantis-health.atlassian.net/browse/VT-7918)

## Changes
- Made canScheduleExactAlarms to always return true on iOS since exact alarm restriction is only on Android